### PR TITLE
Fix - Directory Creation issue

### DIFF
--- a/pd2dsy.py
+++ b/pd2dsy.py
@@ -131,6 +131,7 @@ def main():
     print(("Converting {} for {} platform".format(basename, board)))
 
     # run heavy
+    os.mkdir(basename)
     command = 'python hvcc/hvcc.py {} -o {} -n {} -g c'.format(inpath, basename, basename)
     os.system(command)
 


### PR DESCRIPTION
create dir before hvcc tries and fails. Think this has to do with the fact that we're calling hvcc  from `os.command`. This seems to fix the issue without sudo on my end, but I only tested on windows and debian (via WSL).