### PR TITLE
Introducing sendhook to receive output from pd patch

### DIFF
--- a/util/template.cpp
+++ b/util/template.cpp
@@ -20,11 +20,18 @@ void audiocallback(float **in, float **out, size_t size)
     ProcessControls();
 }
 
+static void sendHook(HeavyContextInterface *c, const char *receiverName, uint32_t receiverHash, const HvMessage * m) {
+  // Do something with message sent from Pd patch through
+  // [send receiverName @hv_event] object(s)
+}
+
 int main(void)
 {
     hardware = &boardsHardware;
     // GENERATE PREINIT
     num_params = hv.getParameterInfo(0,NULL);
+
+    hv.setSendHook(sendHook);
 
     hardware->Init();
 


### PR DESCRIPTION
Updated template to allow for hvcc sendhook to receive messages from the pd patch.
I use this (along with modifications in the generated c file) to drive LEDs, GPIO etc. controlled by the Pd patch.
